### PR TITLE
msdkdec: Fix dec to output with DMABuf mem type

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
@@ -1549,13 +1549,14 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
     }
   }
 
-  if (gst_query_find_allocation_meta (query, GST_VIDEO_META_API_TYPE, NULL)
-      && gst_buffer_pool_has_option (pool,
-          GST_BUFFER_POOL_OPTION_VIDEO_ALIGNMENT)) {
+  if ((gst_query_find_allocation_meta (query, GST_VIDEO_META_API_TYPE, NULL)
+          && gst_buffer_pool_has_option (pool,
+              GST_BUFFER_POOL_OPTION_VIDEO_ALIGNMENT)) || thiz->use_dmabuf) {
     GstStructure *config;
     GstAllocator *allocator;
 
     /* If downstream supports video meta and video alignment,
+     * or if downstream requests for DMABuf mem type,
      * we can replace with our own msdk bufferpool and use it
      */
     /* Remove downstream's pool */


### PR DESCRIPTION
The pipeline "gst-launch-1.0 videotestsrc num-buffers=100
! video/x-raw,format=NV12 ! msdkh265enc ! msdkh265dec
! "video/x-raw(memory:DMABuf)" ! fakesink" or replacing fakesink
with filesink will fail when the frame number is larger than the
allocated number of surfaces. This patch can fix this failure by
utilizing the newly created msdk bufferpool instead of the base
decoder's bufferpool during allocation decision.