### PR TITLE
msdkdec: Check width and height of mfxVideoParam before allocation

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
@@ -1500,6 +1500,9 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
   GstCaps *pool_caps /*, *negotiated_caps */ ;
   guint size, min_buffers, max_buffers;
 
+  if (!thiz->param.mfx.FrameInfo.Width || !thiz->param.mfx.FrameInfo.Height)
+    return FALSE;
+
   if (!GST_VIDEO_DECODER_CLASS (parent_class)->decide_allocation (decoder,
           query))
     return FALSE;


### PR DESCRIPTION
DecodeHeader must be called to fill the mfxVideoParam before allocation,
and thus the check for width and height in mfxVideoParam is necessary.