### PR TITLE
msdkenc: Change default ref frames number as 0

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.c
@@ -95,7 +95,7 @@ static GstStaticPadTemplate sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
 #define PROP_QPP_DEFAULT                 0
 #define PROP_QPB_DEFAULT                 0
 #define PROP_GOP_SIZE_DEFAULT            256
-#define PROP_REF_FRAMES_DEFAULT          1
+#define PROP_REF_FRAMES_DEFAULT          0
 #define PROP_I_FRAMES_DEFAULT            0
 #define PROP_B_FRAMES_DEFAULT            0
 #define PROP_NUM_SLICES_DEFAULT          0


### PR DESCRIPTION
When user does not set ref-frames in pipeline, we should let MediaSDK
decide the reference frame number via setting default value as 0 at
gstreamer side.