### PR TITLE
kmssink: implement set_window_handle interface

### DIFF
--- a/subprojects/gst-plugins-bad/sys/kms/gstkmssink.h
+++ b/subprojects/gst-plugins-bad/sys/kms/gstkmssink.h
@@ -93,6 +93,9 @@ struct _GstKMSSink {
   /* reconfigure info if driver doesn't scale */
   GstVideoRectangle pending_rect;
   gboolean reconfigure;
+
+  gboolean is_internal_fd;
+  gboolean is_running;
 };
 
 struct _GstKMSSinkClass {


### PR DESCRIPTION
Implement the interface for GstVideoOverlay's set_window_handle.

This allows an application to provide their own opened DRM device
fd handle to kmssink.  For example, an application can lease
multiple fd's from a DRM master to display on different CRTC
outputs at the same time with multiple kmssink instances.

cc: @HeJunyan @xhaihao @xuguangxin