### PR TITLE
msdkvpp: correct the fixated caps for src pad

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvpp.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvpp.c
@@ -1453,7 +1453,7 @@ gst_msdkvpp_fixate_caps (GstBaseTransform * trans,
   gboolean *use_dmabuf;
 
   if (direction == GST_PAD_SRC) {
-    result = gst_caps_fixate (result);
+    result = gst_caps_fixate (othercaps);
     use_dmabuf = &thiz->use_sinkpad_dmabuf;
   } else {
     /*


### PR DESCRIPTION
In src pad, fixate othercaps instead of the NULL result caps