### PR TITLE
msdk: Remove unreachable statement

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
@@ -1702,8 +1702,6 @@ failed:
     gst_caps_unref (in_caps);
   if (out_caps)
     gst_caps_unref (out_caps);
-  if (dma_caps)
-    gst_caps_unref (dma_caps);
 
   return FALSE;
 }


### PR DESCRIPTION
The execution cannot reach the statement: "gst_caps_unref(dma_caps);", so remove it.