### PR TITLE
msdkmjpegdec: fix ColorFormat for BGRx format

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
@@ -917,6 +917,7 @@ _jpegdec_set_color_format (mfxVideoParam * param, GstVideoFormat format)
       param->mfx.JPEGColorFormat = MFX_JPEG_COLORFORMAT_YCbCr;
       break;
     case GST_VIDEO_FORMAT_BGRA:
+    case GST_VIDEO_FORMAT_BGRx:
       param->mfx.JPEGColorFormat = MFX_JPEG_COLORFORMAT_RGB;
       break;
     default:


### PR DESCRIPTION
For msdkmjpegdec, the BGRx format is supported in src caps, set the ColorFormat to MFX_JPEG_COLORFORMAT_RGB.