### PR TITLE
Msdkenc insert keyframe

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.h
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.h
@@ -89,6 +89,7 @@ enum
   GST_MSDKENC_PROP_LOWDELAY_BRC,
   GST_MSDKENC_PROP_MAX_FRAME_SIZE_I,
   GST_MSDKENC_PROP_MAX_FRAME_SIZE_P,
+  GST_MSDKENC_PROP_FORCE_KEYFRAME_INTERVAL,
   GST_MSDKENC_PROP_MAX,
 };
 
@@ -160,6 +161,7 @@ struct _GstMsdkEnc
   guint max_frame_size_i;
   guint max_frame_size_p;
   gint16 lowdelay_brc;
+  guint force_keyframe_interval;
 
   GstClockTime start_pts;
   GstClockTime frame_duration;

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.h
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.h
@@ -90,6 +90,7 @@ enum
   GST_MSDKENC_PROP_MAX_FRAME_SIZE_I,
   GST_MSDKENC_PROP_MAX_FRAME_SIZE_P,
   GST_MSDKENC_PROP_FORCE_KEYFRAME_INTERVAL,
+  GST_MSDKENC_PROP_FORCE_IDR,
   GST_MSDKENC_PROP_MAX,
 };
 
@@ -162,6 +163,7 @@ struct _GstMsdkEnc
   guint max_frame_size_p;
   gint16 lowdelay_brc;
   guint force_keyframe_interval;
+  gboolean force_idr;
 
   GstClockTime start_pts;
   GstClockTime frame_duration;


### PR DESCRIPTION
Add two properties (1) force-keyframe-interval: user can set the interval between to insert keyframe; (2) force_idr: user can set this flag as true to force I frames as IDR frames.

There is one point that needs to further consider: normally we should allow force_idr to force any I frame in the clip to be forced as IDR instead of just some frames forced by force-keyframe-interval. But in msdkenc, we don't have any API to know the frame type, which means currently it only works when we set these two properties at the same time.  Recognizing the frame type can be done by parsing the slice header like gst-va does, but it will introduce more redundant parts, like constructing GOP...