### PR TITLE
Msdk modifier

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkallocator_libva.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkallocator_libva.c
@@ -101,6 +101,7 @@ gst_msdk_frame_alloc (mfxHDL pthis, mfxFrameAllocRequest * req,
     GstVideoInfo info;
     GstCaps *caps;
     GstVideoAlignment align;
+    guint min_buffers, max_buffers;
 
     format = gst_msdk_get_video_format_from_mfx_fourcc (fourcc);
     gst_video_info_set_format (&info, format, req->Info.CropW, req->Info.CropH);
@@ -110,16 +111,19 @@ gst_msdk_frame_alloc (mfxHDL pthis, mfxFrameAllocRequest * req,
         (&info, req->Info.Width, req->Info.Height, &align);
     gst_video_info_align (&info, &align);
 
-    caps = gst_video_info_to_caps (&info);
-
     pool = gst_msdk_context_get_alloc_pool (context);
     if (!pool) {
       goto error_alloc;
     }
 
     config = gst_buffer_pool_get_config (GST_BUFFER_POOL_CAST (pool));
+    if (!gst_buffer_pool_config_get_params (config, &caps, NULL, &min_buffers,
+            &max_buffers))
+      goto error_alloc;
+
+    max_buffers = MAX (max_buffers, surfaces_num);
     gst_buffer_pool_config_set_params (config, caps,
-        GST_VIDEO_INFO_SIZE (&info), surfaces_num, surfaces_num);
+        GST_VIDEO_INFO_SIZE (&info), min_buffers, max_buffers);
     gst_buffer_pool_config_add_option (config,
         GST_BUFFER_POOL_OPTION_VIDEO_META);
     gst_buffer_pool_config_add_option (config,

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkallocator_libva.h
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkallocator_libva.h
@@ -49,6 +49,10 @@ gboolean
 gst_msdk_replace_mfx_memid (GstMsdkContext *context,
     mfxFrameSurface1 *mfx_surface, VASurfaceID surface_id);
 
+void
+gst_msdk_get_supported_modifiers (GstMsdkContext * context,
+    GstMsdkContextJobType job_type, GstVideoFormat format, GValue * modifiers);
+
 G_END_DECLS
 
 #endif /* GST_MSDK_ALLOCATOR_LIBVA_H_ */

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
@@ -33,6 +33,7 @@
 
 #ifndef _WIN32
 #include <libdrm/drm_fourcc.h>
+#include <gst/video/video-info-dma.h>
 #include "gstmsdkallocator_libva.h"
 #include <gst/va/gstvavideoformat.h>
 #endif
@@ -2046,6 +2047,11 @@ gst_msdkcaps_video_info_from_caps (const GstCaps * caps,
     if (modifier)
       *modifier = drm_info->drm_modifier;
 
+    /* We need to update the offset/stride in info */
+    GstVideoFormat drm_video_format =
+        gst_va_video_format_from_drm_fourcc (drm_info->drm_fourcc);
+    gst_video_info_set_format
+        (info, drm_video_format, drm_info->vinfo.width, drm_info->vinfo.height);
     gst_video_info_dma_drm_free (drm_info);
   } else
 #endif

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
@@ -30,6 +30,10 @@
  */
 
 #include "gstmsdkcaps.h"
+#ifndef _WIN32
+#include <libdrm/drm_fourcc.h>
+#include "gstmsdkallocator_libva.h"
+#endif
 
 #define DEFAULT_DELIMITER ", "
 #define PROFILE_DELIMITER DEFAULT_DELIMITER
@@ -215,6 +219,105 @@ _get_media_type (guint codec)
 
   return NULL;
 }
+
+#ifndef _WIN32
+static gboolean
+_dma_fmt_to_dma_drm_fmts (GstMsdkContext * context,
+    GstMsdkContextJobType job_type,
+    const GValue * dma_fmts, GValue * dma_drm_fmts)
+{
+  const gchar *fmt_str;
+  gchar *drm_fmt_str;
+  guint32 drm_fourcc;
+  guint64 modifier;
+  GstVideoFormat fmt;
+  GValue gval = G_VALUE_INIT;
+  GValue mods = G_VALUE_INIT;
+
+  g_return_val_if_fail (dma_fmts != NULL, FALSE);
+  g_return_val_if_fail (context != NULL, FALSE);
+
+  fmt_str = g_value_get_string (dma_fmts);
+  fmt = gst_video_format_from_string (fmt_str);
+
+  g_return_val_if_fail (fmt != GST_VIDEO_FORMAT_UNKNOWN, FALSE);
+
+  drm_fourcc = gst_va_drm_fourcc_from_video_format (fmt);
+  if (drm_fourcc == DRM_FORMAT_INVALID)
+    return FALSE;
+
+  g_value_init (&mods, GST_TYPE_LIST);
+  g_value_init (&gval, G_TYPE_STRING);
+
+  gst_msdk_get_supported_modifiers (context, job_type, fmt, &mods);
+
+  for (gint m = 0; m < gst_value_list_get_size (&mods); m++) {
+    const GValue *gmod = gst_value_list_get_value (&mods, m);
+    modifier = g_value_get_uint64 (gmod);
+
+    drm_fmt_str = gst_video_dma_drm_fourcc_to_string (drm_fourcc, modifier);
+    if (!drm_fmt_str)
+      continue;
+
+    g_value_set_string (&gval, drm_fmt_str);
+    gst_value_list_append_value (dma_drm_fmts, &gval);
+
+    GST_DEBUG ("Got modifier: %s", drm_fmt_str);
+    g_free (drm_fmt_str);
+  }
+  g_value_unset (&mods);
+  g_value_unset (&gval);
+
+  return TRUE;
+}
+
+static gboolean
+_dma_fmts_to_dma_drm_fmts (GstMsdkContext * context,
+    GstMsdkContextJobType job_type,
+    const GValue * dma_fmts, GValue * dma_drm_fmts)
+{
+  gint size = gst_value_list_get_size (dma_fmts);
+
+  for (gint f = 0; f < size; f++) {
+    const GValue *dma_fmt = gst_value_list_get_value (dma_fmts, f);
+    if (!dma_fmt)
+      continue;
+
+    _dma_fmt_to_dma_drm_fmts (context, job_type, dma_fmt, dma_drm_fmts);
+  }
+
+  return TRUE;
+}
+
+static GstCaps *
+_create_dma_drm_caps (GstMsdkContext * context,
+    GstMsdkContextJobType job_type, const GValue * dma_formats)
+{
+  GstCaps *dma_drm_caps = NULL;
+  GValue dma_drm_fmts = G_VALUE_INIT;
+
+  g_return_val_if_fail (context != NULL, FALSE);
+  g_return_val_if_fail (dma_formats != NULL, FALSE);
+
+  g_value_init (&dma_drm_fmts, GST_TYPE_LIST);
+
+  if (GST_VALUE_HOLDS_LIST (dma_formats))
+    _dma_fmts_to_dma_drm_fmts (context, job_type, dma_formats, &dma_drm_fmts);
+  else if (G_VALUE_HOLDS_STRING (dma_formats))
+    _dma_fmt_to_dma_drm_fmts (context, job_type, dma_formats, &dma_drm_fmts);
+
+  if (gst_value_list_get_size (&dma_drm_fmts) > 0) {
+    dma_drm_caps = gst_caps_from_string ("video/x-raw(memory:DMABuf)");
+    gst_caps_set_simple (dma_drm_caps, "format", G_TYPE_STRING, "DMA_DRM",
+        NULL);
+    gst_caps_set_value (dma_drm_caps, "drm-format", &dma_drm_fmts);
+  }
+
+  g_value_unset (&dma_drm_fmts);
+
+  return dma_drm_caps;
+}
+#endif
 
 #if (MFX_VERSION >= 2000)
 
@@ -753,8 +856,8 @@ _enc_create_sink_caps (GstMsdkContext * context, guint codec_id,
   gst_caps_set_value (caps, "format", supported_formats);
 
 #ifndef _WIN32
-  dma_caps = gst_caps_from_string ("video/x-raw(memory:DMABuf)");
-  gst_caps_set_value (dma_caps, "format", supported_formats);
+  dma_caps = _create_dma_drm_caps (context, GST_MSDK_JOB_ENCODER,
+      supported_formats);
   gst_caps_append (caps, dma_caps);
 
   gst_caps_append (caps,
@@ -1077,8 +1180,8 @@ _dec_create_src_caps (GstMsdkContext * context,
   gst_caps_set_value (caps, "format", supported_formats);
 
 #ifndef _WIN32
-  dma_caps = gst_caps_from_string ("video/x-raw(memory:DMABuf)");
-  gst_caps_set_value (dma_caps, "format", supported_formats);
+  dma_caps = _create_dma_drm_caps (context, GST_MSDK_JOB_DECODER,
+      supported_formats);
   gst_caps_append (caps, dma_caps);
 
   gst_caps_append (caps,
@@ -1326,8 +1429,7 @@ _vpp_create_caps (GstMsdkContext * context,
   gst_caps_set_value (caps, "format", supported_fmts);
 
 #ifndef _WIN32
-  dma_caps = gst_caps_from_string ("video/x-raw(memory:DMABuf)");
-  gst_caps_set_value (dma_caps, "format", supported_fmts);
+  dma_caps = _create_dma_drm_caps (context, GST_MSDK_JOB_VPP, supported_fmts);
   gst_caps_append (caps, dma_caps);
 
   gst_caps_append (caps,
@@ -1521,10 +1623,11 @@ gst_msdkcaps_enc_create_static_caps (GstMsdkContext * context,
 {
   GstCaps *in_caps = NULL, *out_caps = NULL;
   GstCaps *dma_caps = NULL;
-  gchar *raw_caps_str, *dma_caps_str;
+  gchar *raw_caps_str;
   const gchar *media_type = NULL;
   const char *raw_fmts = NULL;
-  const char *dma_fmts = NULL;
+  const char *dma_fmts_str = NULL;
+  GValue dma_fmts = G_VALUE_INIT;
   GValue supported_profs = G_VALUE_INIT;
 
   raw_fmts = _enc_get_static_raw_formats (codec_id);
@@ -1536,21 +1639,23 @@ gst_msdkcaps_enc_create_static_caps (GstMsdkContext * context,
   g_free (raw_caps_str);
 
 #ifndef _WIN32
-  dma_fmts = _enc_get_static_dma_formats (codec_id);
-  if (!dma_fmts)
+  dma_fmts_str = _enc_get_static_dma_formats (codec_id);
+  if (!dma_fmts_str)
     goto failed;
-  dma_caps_str =
-      g_strdup_printf ("video/x-raw(memory:DMABuf), format=(string){ %s }",
-      dma_fmts);
-  dma_caps = gst_caps_from_string (dma_caps_str);
-  g_free (dma_caps_str);
+
+  g_value_init (&dma_fmts, GST_TYPE_LIST);
+  _strings_to_list (dma_fmts_str, &dma_fmts);
+
+  dma_caps = _create_dma_drm_caps (context, GST_MSDK_JOB_ENCODER, &dma_fmts);
+  g_value_unset (&dma_fmts);
   gst_caps_append (in_caps, dma_caps);
 
   gst_caps_append (in_caps,
       gst_caps_from_string
       ("video/x-raw(memory:VAMemory), format=(string){ NV12 }"));
 #else
-  VAR_UNUSED (dma_caps_str);
+  VAR_UNUSED (dma_caps);
+  VAR_UNUSED (dma_fmts_str);
   VAR_UNUSED (dma_fmts);
   gst_caps_append (in_caps,
       gst_caps_from_string
@@ -1669,10 +1774,11 @@ gst_msdkcaps_dec_create_static_caps (GstMsdkContext * context,
 {
   GstCaps *in_caps = NULL, *out_caps = NULL;
   GstCaps *dma_caps = NULL;
-  gchar *raw_caps_str, *dma_caps_str;
+  gchar *raw_caps_str;
   const gchar *media_type = NULL;
   const char *raw_fmts = NULL;
-  const char *dma_fmts = NULL;
+  const char *dma_fmts_str = NULL;
+  GValue dma_fmts = G_VALUE_INIT;
 
   media_type = _get_media_type (codec_id);
   if (!media_type)
@@ -1689,14 +1795,15 @@ gst_msdkcaps_dec_create_static_caps (GstMsdkContext * context,
   g_free (raw_caps_str);
 
 #ifndef _WIN32
-  dma_fmts = _dec_get_static_dma_formats (codec_id);
-  if (!dma_fmts)
+  dma_fmts_str = _dec_get_static_dma_formats (codec_id);
+  if (!dma_fmts_str)
     goto failed;
-  dma_caps_str =
-      g_strdup_printf ("video/x-raw(memory:DMABuf), format=(string){ %s }",
-      dma_fmts);
-  dma_caps = gst_caps_from_string (dma_caps_str);
-  g_free (dma_caps_str);
+
+  g_value_init (&dma_fmts, GST_TYPE_LIST);
+  _strings_to_list (dma_fmts_str, &dma_fmts);
+
+  dma_caps = _create_dma_drm_caps (context, GST_MSDK_JOB_DECODER, &dma_fmts);
+  g_value_unset (&dma_fmts);
   gst_caps_append (out_caps, dma_caps);
 
   gst_caps_append (out_caps,
@@ -1704,7 +1811,7 @@ gst_msdkcaps_dec_create_static_caps (GstMsdkContext * context,
       ("video/x-raw(memory:VAMemory), format=(string){ NV12 }"));
 #else
   VAR_UNUSED (dma_caps);
-  VAR_UNUSED (dma_caps_str);
+  VAR_UNUSED (dma_fmts_str);
   VAR_UNUSED (dma_fmts);
   gst_caps_append (out_caps,
       gst_caps_from_string
@@ -1777,6 +1884,7 @@ _vpp_create_static_caps (GstMsdkContext * context, GstPadDirection direction)
 {
   GstCaps *caps = NULL, *dma_caps = NULL;
   gchar *caps_str;
+  GValue dma_fmts = G_VALUE_INIT;
 
   caps_str = g_strdup_printf ("video/x-raw, format=(string){ %s }",
       _vpp_get_static_raw_formats (direction));
@@ -1784,18 +1892,18 @@ _vpp_create_static_caps (GstMsdkContext * context, GstPadDirection direction)
   g_free (caps_str);
 
 #ifndef _WIN32
-  caps_str =
-      g_strdup_printf ("video/x-raw(memory:DMABuf), format=(string){ %s }",
-      _vpp_get_static_dma_formats (direction));
-  dma_caps = gst_caps_from_string (caps_str);
-  g_free (caps_str);
+  g_value_init (&dma_fmts, GST_TYPE_LIST);
+  _strings_to_list (_vpp_get_static_dma_formats (direction), &dma_fmts);
+
+  dma_caps = _create_dma_drm_caps (context, GST_MSDK_JOB_VPP, &dma_fmts);
+  g_value_unset (&dma_fmts);
   gst_caps_append (caps, dma_caps);
 
   gst_caps_append (caps, gst_caps_from_string ("video/x-raw(memory:VAMemory), "
           "format=(string){ NV12, VUYA, P010_10LE }"));
 #else
   VAR_UNUSED (dma_caps);
-  VAR_UNUSED (caps_str);
+  VAR_UNUSED (dma_fmts);
 
   gst_caps_append (caps,
       gst_caps_from_string ("video/x-raw(memory:D3D11Memory), "

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
@@ -30,9 +30,11 @@
  */
 
 #include "gstmsdkcaps.h"
+
 #ifndef _WIN32
 #include <libdrm/drm_fourcc.h>
 #include "gstmsdkallocator_libva.h"
+#include <gst/va/gstvavideoformat.h>
 #endif
 
 #define DEFAULT_DELIMITER ", "
@@ -1991,7 +1993,13 @@ gst_msdkcaps_set_strings (GstCaps * caps,
     if (!s)
       return FALSE;
 
-    gst_structure_set_value (s, field, &list);
+    /* When we use this function to get a fixated caps, we should set
+     * a single value instead of a list in the corresponding filed.
+     */
+    if (gst_value_list_get_size (&list) == 1)
+      gst_structure_set_value (s, field, gst_value_list_get_value (&list, 0));
+    else
+      gst_structure_set_value (s, field, &list);
   } else {
     gst_caps_set_value (caps, field, &list);
   }
@@ -2020,3 +2028,83 @@ gst_msdkcaps_remove_structure (GstCaps * caps, const gchar * features)
 
   return TRUE;
 }
+
+gboolean
+gst_msdkcaps_video_info_from_caps (const GstCaps * caps,
+    GstVideoInfo * info, guint64 * modifier)
+{
+  g_return_val_if_fail (caps != NULL, FALSE);
+  g_return_val_if_fail (info != NULL, FALSE);
+
+#ifndef _WIN32
+  if (gst_video_is_dma_drm_caps (caps)) {
+    GstVideoInfoDmaDrm *drm_info = gst_video_info_dma_drm_new_from_caps (caps);
+    if (!drm_info)
+      goto failed;
+
+    *info = drm_info->vinfo;
+    if (modifier)
+      *modifier = drm_info->drm_modifier;
+
+    gst_video_info_dma_drm_free (drm_info);
+  } else
+#endif
+
+  if (!gst_video_info_from_caps (info, caps))
+    goto failed;
+
+  return TRUE;
+
+failed:
+  GST_ERROR_OBJECT (caps, "Failed to get video info fom caps");
+  return FALSE;
+}
+
+#ifndef _WIN32
+GstCaps *
+gst_msdkcaps_video_info_to_drm_caps (GstVideoInfo * info, guint64 modifier)
+{
+  GstVideoInfoDmaDrm drm_info;
+
+  gst_video_info_dma_drm_init (&drm_info);
+  drm_info.vinfo = *info;
+  drm_info.drm_fourcc =
+      gst_va_drm_fourcc_from_video_format (GST_VIDEO_INFO_FORMAT (info));
+  drm_info.drm_modifier = modifier;
+
+  return gst_video_info_dma_drm_to_caps (&drm_info);
+}
+
+guint64
+get_msdkcaps_get_modifier (const GstCaps * caps)
+{
+  guint64 modifier = DRM_FORMAT_MOD_INVALID;
+  guint size = gst_caps_get_size (caps);
+
+  for (guint i = 0; i < size; i++) {
+    GstCapsFeatures *f = gst_caps_get_features (caps, i);
+
+    if (gst_caps_features_contains (f, GST_CAPS_FEATURE_MEMORY_DMABUF)) {
+      GstStructure *s = gst_caps_get_structure (caps, i);
+      const GValue *drm_fmts = gst_structure_get_value (s, "drm-format");
+      const gchar *drm_str = NULL;
+
+      if (!drm_fmts)
+        continue;
+
+      if (G_VALUE_HOLDS_STRING (drm_fmts))
+        drm_str = g_value_get_string (drm_fmts);
+      else if (GST_VALUE_HOLDS_LIST (drm_fmts)) {
+        const GValue *val = gst_value_list_get_value (drm_fmts, 0);
+        drm_str = g_value_get_string (val);
+      }
+
+      gst_video_dma_drm_fourcc_from_string (drm_str, &modifier);
+    }
+  }
+
+  GST_DEBUG ("got modifier: 0x%016lx", modifier);
+
+  return modifier;
+}
+#endif

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.h
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.h
@@ -81,6 +81,18 @@ gst_msdkcaps_set_strings (GstCaps * caps,
 gboolean
 gst_msdkcaps_remove_structure (GstCaps * caps, const gchar * features);
 
+gboolean
+gst_msdkcaps_video_info_from_caps (const GstCaps * caps,
+    GstVideoInfo * info, guint64 * modifier);
+
+#ifndef _WIN32
+GstCaps *
+gst_msdkcaps_video_info_to_drm_caps (GstVideoInfo * info, guint64 modifier);
+
+guint64
+get_msdkcaps_get_modifier (const GstCaps * caps);
+#endif
+
 G_END_DECLS
 
 #endif /* __GST_MSDKCAPS_H__ */

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.c
@@ -38,9 +38,12 @@
 #include "gstmsdkdec.h"
 #include "gstmsdkcontextutil.h"
 #include "gstmsdkallocator.h"
+#include "gstmsdkcaps.h"
 
 #ifndef _WIN32
+#include <libdrm/drm_fourcc.h>
 #include <gst/va/gstvaallocator.h>
+#include <gst/va/gstvavideoformat.h>
 #else
 #include <gst/d3d11/gstd3d11.h>
 #endif
@@ -509,7 +512,7 @@ failed:
 }
 
 static gboolean
-pad_accept_memory (GstMsdkDec * thiz, const gchar * mem_type, GstCaps * filter)
+pad_accept_memory (GstMsdkDec * thiz, const gchar * mem_type, GstCaps ** filter)
 {
   gboolean ret = FALSE;
   GstCaps *caps, *out_caps;
@@ -517,23 +520,37 @@ pad_accept_memory (GstMsdkDec * thiz, const gchar * mem_type, GstCaps * filter)
 
   pad = GST_VIDEO_DECODER_SRC_PAD (thiz);
 
-  /* make a copy of filter caps since we need to alter the structure
-   * by adding dmabuf-capsfeatures */
-  caps = gst_caps_copy (filter);
+  caps = gst_caps_copy (*filter);
   gst_caps_set_features (caps, 0, gst_caps_features_from_string (mem_type));
 
+#ifndef _WIN32
+  /* In dma caps case, we need to set drm-format for raw caps */
+  if (gst_msdkcaps_has_feature (caps, GST_CAPS_FEATURE_MEMORY_DMABUF)) {
+    GstStructure *s = gst_caps_get_structure (caps, 0);
+
+    if (gst_structure_has_field (s, "format")) {
+      const gchar *fmt_str = gst_structure_get_string (s, "format");
+      GstVideoFormat fmt = gst_video_format_from_string (fmt_str);
+      guint32 fourcc = gst_va_drm_fourcc_from_video_format (fmt);
+      gchar *drm_str =
+          gst_video_dma_drm_fourcc_to_string (fourcc, thiz->modifier);
+      gst_msdkcaps_set_strings (caps, mem_type, "drm-format", drm_str);
+      gst_caps_set_simple (caps, "format", G_TYPE_STRING, "DMA_DRM", NULL);
+    }
+  }
+#endif
+
   out_caps = gst_pad_peer_query_caps (pad, caps);
-  if (!out_caps)
+
+  if (!out_caps || gst_caps_is_empty (out_caps))
     goto done;
 
-  if (gst_caps_is_any (out_caps) || gst_caps_is_empty (out_caps))
-    goto done;
-
-  if (gst_msdkcaps_has_feature (out_caps, mem_type))
+  if (gst_msdkcaps_has_feature (out_caps, mem_type)) {
+    *filter = caps;
     ret = TRUE;
+  }
+
 done:
-  if (caps)
-    gst_caps_unref (caps);
   if (out_caps)
     gst_caps_unref (out_caps);
   return ret;
@@ -559,24 +576,68 @@ gst_msdkdec_getcaps (GstVideoDecoder * decoder, GstCaps * filter)
 }
 
 static gboolean
+gst_msdkdec_fixate_format (GstMsdkDec * thiz, GstCaps * caps,
+    GstVideoFormat fmt)
+{
+  GValue gfmt = G_VALUE_INIT;
+
+  g_return_val_if_fail (caps != NULL, FALSE);
+  g_return_val_if_fail (gst_caps_is_writable (caps), FALSE);
+  g_return_val_if_fail (fmt != GST_VIDEO_FORMAT_UNKNOWN, FALSE);
+
+  g_value_init (&gfmt, G_TYPE_STRING);
+
+  for (guint i = 0; i < gst_caps_get_size (caps); i++) {
+    GstStructure *s = gst_caps_get_structure (caps, i);
+
+#ifndef _WIN32
+    GstCapsFeatures *f = gst_caps_get_features (caps, i);
+    if (gst_caps_features_contains (f, GST_CAPS_FEATURE_MEMORY_DMABUF)) {
+      const GValue *drm_fmts = gst_structure_get_value (s, "drm-format");
+      guint32 fourcc = gst_va_drm_fourcc_from_video_format (fmt);
+      gchar *drm_str =
+          gst_video_dma_drm_fourcc_to_string (fourcc, thiz->modifier);
+      g_value_set_string (&gfmt, drm_str);
+      if (!gst_value_can_intersect (&gfmt, drm_fmts))
+        goto failed;
+      gst_structure_set_value (s, "drm-format", &gfmt);
+      continue;
+    }
+#endif
+
+    const GValue *fmts = gst_structure_get_value (s, "format");
+    g_value_set_string (&gfmt, gst_video_format_to_string (fmt));
+    if (!gst_value_can_intersect (&gfmt, fmts))
+      goto failed;
+    gst_structure_set_value (s, "format", &gfmt);
+  }
+
+  g_value_unset (&gfmt);
+  return TRUE;
+
+failed:
+  g_value_unset (&gfmt);
+  return FALSE;
+}
+
+static gboolean
 gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
 {
   GstVideoCodecState *output_state;
   GstVideoInfo vinfo;
   GstVideoAlignment align;
   GstCaps *allocation_caps = NULL;
-  GstCaps *allowed_caps = NULL, *temp_caps;
+  GstCaps *allowed_caps = NULL, *temp_caps, *out_caps, *src_caps;
   GstVideoFormat format;
   guint width, height;
   guint alloc_w, alloc_h;
   int out_width = 0, out_height = 0;
   gint dar_n = -1, dar_d = -1;
-  const gchar *format_str;
   GstStructure *outs = NULL;
   const gchar *out_format;
-  GValue v_format = G_VALUE_INIT;
   GValue v_width = G_VALUE_INIT;
   GValue v_height = G_VALUE_INIT;
+  gboolean has_drm_format = FALSE;
 
   /* use display width and display height in output state, which
    * will be used for caps negotiation */
@@ -595,6 +656,19 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
     GST_WARNING_OBJECT (thiz, "Failed to find a valid video format");
     return FALSE;
   }
+
+  src_caps = gst_pad_query_caps (GST_VIDEO_DECODER (thiz)->srcpad, NULL);
+  temp_caps = gst_caps_make_writable (src_caps);
+
+
+#ifndef _WIN32
+  /* Get possible modifier before negotiation really happens */
+  GstVaDisplay *display =
+      (GstVaDisplay *) gst_msdk_context_get_va_display (thiz->context);
+  thiz->modifier = gst_va_dmabuf_get_modifier_for_format (display, format,
+      VA_SURFACE_ATTRIB_USAGE_HINT_DECODER);
+#endif
+
 #if (MFX_VERSION >= 1022)
   /* SFC is triggered (for AVC and HEVC) when default output format is not
    * accepted by downstream or when downstream requests for a smaller
@@ -606,18 +680,17 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
    * and let SFC work. */
   if (thiz->param.mfx.CodecId == MFX_CODEC_AVC ||
       thiz->param.mfx.CodecId == MFX_CODEC_HEVC) {
-    temp_caps = gst_pad_query_caps (GST_VIDEO_DECODER (thiz)->srcpad, NULL);
-    temp_caps = gst_caps_make_writable (temp_caps);
-
-    g_value_init (&v_format, G_TYPE_STRING);
+    if (!gst_msdkdec_fixate_format (thiz, temp_caps, format)) {
+      GST_ERROR_OBJECT (thiz, "Format is not negotiable");
+      gst_caps_unref (temp_caps);
+      return FALSE;
+    }
     g_value_init (&v_width, G_TYPE_INT);
     g_value_init (&v_height, G_TYPE_INT);
 
-    g_value_set_string (&v_format, gst_video_format_to_string (format));
     g_value_set_int (&v_width, width);
     g_value_set_int (&v_height, height);
 
-    gst_caps_set_value (temp_caps, "format", &v_format);
     gst_caps_set_value (temp_caps, "width", &v_width);
     gst_caps_set_value (temp_caps, "height", &v_height);
 
@@ -635,14 +708,29 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
       allowed_caps =
           gst_pad_get_allowed_caps (GST_VIDEO_DECODER (thiz)->srcpad);
       outs = gst_caps_get_structure (allowed_caps, 0);
-      out_format = gst_structure_get_string (outs, "format");
-      gst_structure_get_int (outs, "width", &out_width);
-      gst_structure_get_int (outs, "height", &out_height);
+
+      if (gst_structure_has_field (outs, "drm-format")) {
+        out_format = gst_structure_get_string (outs, "drm-format");
+        has_drm_format = TRUE;
+      } else {
+        out_format = gst_structure_get_string (outs, "format");
+      }
 
       if (out_format) {
-        format = gst_video_format_from_string (out_format);
+        if (has_drm_format) {
+#ifndef _WIN32
+          guint drm_fourcc =
+              gst_video_dma_drm_fourcc_from_string (out_format, NULL);
+          format = gst_va_video_format_from_drm_fourcc (drm_fourcc);
+#endif
+        } else {
+          format = gst_video_format_from_string (out_format);
+        }
         thiz->sfc = TRUE;
       }
+
+      gst_structure_get_int (outs, "width", &out_width);
+      gst_structure_get_int (outs, "height", &out_height);
 
       if (!out_width && !out_height) {
         out_width = width;
@@ -665,9 +753,9 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
       }
       gst_caps_unref (allowed_caps);
     }
-    gst_caps_unref (temp_caps);
   }
 #endif
+  gst_caps_unref (temp_caps);
 
   output_state =
       gst_video_decoder_set_output_state (GST_VIDEO_DECODER (thiz),
@@ -691,23 +779,22 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
   else
     gst_msdk_set_video_alignment (&vinfo, alloc_w, alloc_h, &align);
   gst_video_info_align (&vinfo, &align);
-  output_state->caps = gst_video_info_to_caps (&vinfo);
+
+  out_caps = gst_video_info_to_caps (&vinfo);
+
 #ifndef _WIN32
-  if (pad_accept_memory (thiz, GST_CAPS_FEATURE_MEMORY_VA, output_state->caps)) {
-    gst_caps_set_features (output_state->caps, 0,
-        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_VA, NULL));
+  if (pad_accept_memory (thiz, GST_CAPS_FEATURE_MEMORY_VA, &out_caps)) {
+    GST_INFO_OBJECT (thiz, "Decoder src pad accepts VAMemory caps");
   } else if (pad_accept_memory (thiz, GST_CAPS_FEATURE_MEMORY_DMABUF,
-          output_state->caps)) {
-    gst_caps_set_features (output_state->caps, 0,
-        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DMABUF, NULL));
+          &out_caps)) {
+    GST_INFO_OBJECT (thiz, "Decoder src pad accepts DMABuf caps");
   }
 #else
-  if (pad_accept_memory (thiz, GST_CAPS_FEATURE_MEMORY_D3D11_MEMORY,
-          output_state->caps)) {
-    gst_caps_set_features (output_state->caps, 0,
-        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_D3D11_MEMORY, NULL));
+  if (pad_accept_memory (thiz, GST_CAPS_FEATURE_MEMORY_D3D11_MEMORY, &out_caps)) {
+    GST_INFO_OBJECT (thiz, "Decoder src pad accepts D3D11Memory caps");
   }
 #endif
+  output_state->caps = out_caps;
 
   if (need_allocation) {
     /* Find allocation width and height */
@@ -721,11 +808,8 @@ gst_msdkdec_set_src_caps (GstMsdkDec * thiz, gboolean need_allocation)
     /* set allocation width and height in allocation_caps,
      * which may or may not be similar to the output_state caps */
     allocation_caps = gst_caps_copy (output_state->caps);
-    format_str =
-        gst_video_format_to_string (GST_VIDEO_INFO_FORMAT
-        (&output_state->info));
     gst_caps_set_simple (allocation_caps, "width", G_TYPE_INT, width, "height",
-        G_TYPE_INT, height, "format", G_TYPE_STRING, format_str, NULL);
+        G_TYPE_INT, height, NULL);
     GST_INFO_OBJECT (thiz, "new alloc caps = %" GST_PTR_FORMAT,
         allocation_caps);
     gst_caps_replace (&output_state->allocation_caps, allocation_caps);
@@ -1431,8 +1515,8 @@ gst_msdkdec_handle_frame (GstVideoDecoder * decoder, GstVideoCodecFrame * frame)
           gst_video_decoder_get_output_state (GST_VIDEO_DECODER (thiz));
       if (output_state) {
         if (output_state->allocation_caps) {
-          if (!gst_video_info_from_caps (&alloc_info,
-                  output_state->allocation_caps)) {
+          if (!gst_msdkcaps_video_info_from_caps (output_state->allocation_caps,
+                  &alloc_info, NULL)) {
             GST_ERROR_OBJECT (thiz, "Failed to get video info from caps");
             flow = GST_FLOW_ERROR;
             goto error;
@@ -1680,7 +1764,14 @@ gst_msdk_create_va_pool (GstMsdkDec * thiz, GstVideoInfo * info,
     return NULL;
   }
 
-  caps = gst_video_info_to_caps (info);
+  if (thiz->use_dmabuf && thiz->modifier != DRM_FORMAT_MOD_INVALID) {
+    caps = gst_msdkcaps_video_info_to_drm_caps (info, thiz->modifier);
+    gst_caps_set_features (caps, 0,
+        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DMABUF, NULL));
+  } else {
+    caps = gst_video_info_to_caps (info);
+  }
+
   pool =
       gst_va_pool_new_with_config (caps,
       GST_VIDEO_INFO_SIZE (info), num_buffers, num_buffers,
@@ -1743,7 +1834,18 @@ gst_msdkdec_create_buffer_pool (GstMsdkDec * thiz, GstVideoInfo * info,
   if (!pool)
     goto error_no_pool;
 
+#ifndef _WIN32
+  if (thiz->use_dmabuf) {
+    caps = gst_msdkcaps_video_info_to_drm_caps (&vinfo, thiz->modifier);
+    gst_caps_set_features (caps, 0,
+        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DMABUF, NULL));
+  } else {
+    caps = gst_video_info_to_caps (&vinfo);
+  }
+#else
   caps = gst_video_info_to_caps (&vinfo);
+#endif
+
   config = gst_buffer_pool_get_config (GST_BUFFER_POOL_CAST (pool));
   gst_buffer_pool_config_set_params (config, caps,
       GST_VIDEO_INFO_SIZE (&vinfo), num_buffers, 0);
@@ -1776,21 +1878,79 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
   GstMsdkDec *thiz = GST_MSDKDEC (decoder);
   GstBufferPool *pool = NULL;
   GstStructure *pool_config = NULL;
-  GstCaps *pool_caps /*, *negotiated_caps */ ;
-  guint size, min_buffers, max_buffers;
+  GstCaps *pool_caps = NULL;
+  guint size = 0;
+  guint min_buffers = 0;
+  guint max_buffers = 0;
   gboolean has_videometa, has_video_alignment;
+
+  GstAllocator *allocator = NULL;
+  GstAllocationParams params;
+  gboolean update_pool = FALSE;
+  gboolean update_allocator = FALSE;
+
+  GstVideoInfo vinfo;
 
   if (!thiz->param.mfx.FrameInfo.Width || !thiz->param.mfx.FrameInfo.Height)
     return FALSE;
 
-  if (!GST_VIDEO_DECODER_CLASS (parent_class)->decide_allocation (decoder,
-          query))
-    return FALSE;
+  gst_query_parse_allocation (query, &pool_caps, NULL);
+
+  if (!gst_msdkcaps_video_info_from_caps (pool_caps, &vinfo, NULL))
+    goto failed_to_parse_caps;
+
+  if (gst_query_get_n_allocation_params (query) > 0) {
+    gst_query_parse_nth_allocation_param (query, 0, &allocator, &params);
+    update_allocator = TRUE;
+  }
+  if (!allocator)
+    gst_allocation_params_init (&params);
+
+  if (gst_query_get_n_allocation_pools (query) > 0) {
+    gst_query_parse_nth_allocation_pool (query,
+        0, &pool, &size, &min_buffers, &max_buffers);
+    update_pool = TRUE;
+  }
+  if (!pool)
+    pool = gst_video_buffer_pool_new ();
+
+  size = MAX (size, vinfo.size);
+  pool_config = gst_buffer_pool_get_config (pool);
+  gst_buffer_pool_config_set_params (pool_config,
+      pool_caps, size, min_buffers, max_buffers);
+  gst_buffer_pool_config_set_allocator (pool_config, allocator, &params);
+
+  if (!gst_buffer_pool_set_config (pool, pool_config)) {
+    pool_config = gst_buffer_pool_get_config (pool);
+
+    if (!gst_buffer_pool_config_validate_params (pool_config,
+            pool_caps, size, min_buffers, max_buffers)) {
+      gst_object_unref (pool);
+      pool = gst_video_buffer_pool_new ();
+      gst_buffer_pool_config_set_params (pool_config,
+          pool_caps, size, min_buffers, max_buffers);
+      gst_buffer_pool_config_set_allocator (pool_config, allocator, &params);
+    }
+
+    if (!gst_buffer_pool_set_config (pool, pool_config))
+      return FALSE;
+  }
+
+  if (update_allocator)
+    gst_query_set_nth_allocation_param (query, 0, allocator, &params);
+  else
+    gst_query_add_allocation_param (query, allocator, &params);
+
+  if (update_pool)
+    gst_query_set_nth_allocation_pool (query,
+        0, pool, size, min_buffers, max_buffers);
+  else
+    gst_query_add_allocation_pool (query, pool, size, min_buffers, max_buffers);
 
   /* Get the buffer pool config decided on by the base class. The base
      class ensures that there will always be at least a 0th pool in
      the query. */
-  gst_query_parse_nth_allocation_pool (query, 0, &pool, NULL, NULL, NULL);
+
   pool_config = gst_buffer_pool_get_config (pool);
 
   has_videometa = gst_query_find_allocation_meta
@@ -1800,8 +1960,6 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
 
   /* Get the caps of pool and increase the min and max buffers by async_depth.
    * We will always have that number of decode operations in-flight */
-  gst_buffer_pool_config_get_params (pool_config, &pool_caps, &size,
-      &min_buffers, &max_buffers);
   min_buffers += thiz->async_depth;
   if (max_buffers)
     max_buffers += thiz->async_depth;
@@ -1831,18 +1989,16 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
     }
   }
 #ifndef _WIN32
-  GstAllocator *allocator = NULL;
-  if (gst_query_get_n_allocation_params (query) > 0) {
-    gst_query_parse_nth_allocation_param (query, 0, &allocator, NULL);
-    if (!(GST_IS_VA_ALLOCATOR (allocator) ||
-            GST_IS_VA_DMABUF_ALLOCATOR (allocator)))
-      thiz->ds_has_known_allocator = FALSE;
-  }
+  if (!(GST_IS_VA_ALLOCATOR (allocator) ||
+          GST_IS_VA_DMABUF_ALLOCATOR (allocator)))
+    thiz->ds_has_known_allocator = FALSE;
 #else
   if (!GST_IS_D3D11_BUFFER_POOL (pool)) {
     thiz->ds_has_known_allocator = FALSE;
   }
 #endif
+  if (allocator)
+    gst_object_unref (allocator);
 
   /* If downstream supports video meta and video alignment, or downstream
    * doesn't have known allocator (known allocator refers to va allocator
@@ -1851,9 +2007,7 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
   if ((has_videometa && has_video_alignment)
       || !thiz->ds_has_known_allocator) {
     GstStructure *config;
-    GstAllocator *allocator;
 
-    /* Remove downstream's pool */
     gst_structure_free (pool_config);
     gst_object_unref (pool);
 
@@ -1879,10 +2033,8 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
         min_buffers, max_buffers);
     if (!gst_buffer_pool_set_config (pool, pool_config))
       goto error_set_config;
-    if (!gst_video_info_from_caps (&thiz->non_msdk_pool_info, pool_caps)) {
-      GST_ERROR_OBJECT (thiz, "Failed to get video info from caps");
-      return FALSE;
-    }
+
+    thiz->non_msdk_pool_info = vinfo;
 
     /* update width and height with actual negotiated values */
     output_state =
@@ -1925,21 +2077,26 @@ gst_msdkdec_decide_allocation (GstVideoDecoder * decoder, GstQuery * query)
   gst_query_set_nth_allocation_pool (query, 0, pool, size, min_buffers,
       max_buffers);
 
-  if (pool)
-    gst_object_unref (pool);
+  gst_caps_unref (pool_caps);
+  gst_object_unref (pool);
 
   return TRUE;
 
+failed_to_parse_caps:
+  GST_ERROR_OBJECT (decoder, "failed to set buffer pool config");
+  gst_caps_unref (pool_caps);
+  return FALSE;
+
 failed_to_create_pool:
   GST_ERROR_OBJECT (decoder, "failed to set buffer pool config");
-  if (pool)
-    gst_object_unref (pool);
+  gst_caps_unref (pool_caps);
+  gst_object_unref (pool);
   return FALSE;
 
 error_set_config:
   GST_ERROR_OBJECT (decoder, "failed to set buffer pool config");
-  if (pool)
-    gst_object_unref (pool);
+  gst_caps_unref (pool_caps);
+  gst_object_unref (pool);
   return FALSE;
 }
 
@@ -2271,6 +2428,9 @@ gst_msdkdec_init (GstMsdkDec * thiz)
   thiz->report_error = FALSE;
   thiz->sfc = FALSE;
   thiz->ds_has_known_allocator = TRUE;
+#ifndef _WIN32
+  thiz->modifier = DRM_FORMAT_MOD_INVALID;
+#endif
   thiz->adapter = gst_adapter_new ();
   thiz->input_state = NULL;
   thiz->pool = NULL;

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.h
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkdec.h
@@ -81,6 +81,7 @@ struct _GstMsdkDec
   gboolean initialized;
   gboolean sfc;
   gboolean ds_has_known_allocator;
+  guint64 modifier;
 
   /* for packetization */
   GstAdapter *adapter;

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.c
@@ -48,8 +48,10 @@
 #include "gstmsdkcontextutil.h"
 #include "gstmsdkallocator.h"
 #include "mfxjpeg.h"
+#include "gstmsdkcaps.h"
 
 #ifndef _WIN32
+#include <libdrm/drm_fourcc.h>
 #include "gstmsdkallocator_libva.h"
 #include <gst/va/gstvaallocator.h>
 #else
@@ -493,7 +495,7 @@ static gboolean
 gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
 {
   GstMsdkEncClass *klass = GST_MSDKENC_GET_CLASS (thiz);
-  GstVideoInfo *info;
+  GstVideoInfo info;
   mfxSession session;
   mfxStatus status;
   mfxFrameAllocRequest request;
@@ -514,7 +516,12 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
     GST_DEBUG_OBJECT (thiz, "Have no input state yet");
     return FALSE;
   }
-  info = &thiz->input_state->info;
+
+  if (!gst_msdkcaps_video_info_from_caps (thiz->input_state->caps, &info,
+          &thiz->modifier)) {
+    GST_WARNING_OBJECT (thiz, "Failed to get video info from input caps");
+    return FALSE;
+  }
 
   GST_OBJECT_LOCK (thiz);
   session = gst_msdk_context_get_session (thiz->context);
@@ -525,7 +532,7 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
 
 #if (MFX_VERSION < 2000)
   /* check the format for MSDK path */
-  if (!klass->is_format_supported (thiz, GST_VIDEO_INFO_FORMAT (info))) {
+  if (!klass->is_format_supported (thiz, GST_VIDEO_INFO_FORMAT (&info))) {
     GST_ERROR_OBJECT (thiz,
         "internal vpp is no longer supported, "
         "please use msdkvpp plugin to do conversion first");
@@ -547,14 +554,14 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
   thiz->param.mfx.NumRefFrame = thiz->ref_frames;
   thiz->param.mfx.EncodedOrder = 0;     /* Take input frames in display order */
 
-  thiz->param.mfx.FrameInfo.Width = GST_ROUND_UP_16 (info->width);
-  thiz->param.mfx.FrameInfo.Height = GST_ROUND_UP_32 (info->height);
-  thiz->param.mfx.FrameInfo.CropW = info->width;
-  thiz->param.mfx.FrameInfo.CropH = info->height;
-  thiz->param.mfx.FrameInfo.FrameRateExtN = info->fps_n;
-  thiz->param.mfx.FrameInfo.FrameRateExtD = info->fps_d;
-  thiz->param.mfx.FrameInfo.AspectRatioW = info->par_n;
-  thiz->param.mfx.FrameInfo.AspectRatioH = info->par_d;
+  thiz->param.mfx.FrameInfo.Width = GST_ROUND_UP_16 (info.width);
+  thiz->param.mfx.FrameInfo.Height = GST_ROUND_UP_32 (info.height);
+  thiz->param.mfx.FrameInfo.CropW = info.width;
+  thiz->param.mfx.FrameInfo.CropH = info.height;
+  thiz->param.mfx.FrameInfo.FrameRateExtN = info.fps_n;
+  thiz->param.mfx.FrameInfo.FrameRateExtD = info.fps_d;
+  thiz->param.mfx.FrameInfo.AspectRatioW = info.par_n;
+  thiz->param.mfx.FrameInfo.AspectRatioH = info.par_d;
   thiz->param.mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_PROGRESSIVE;
   thiz->param.mfx.FrameInfo.ChromaFormat = MFX_CHROMAFORMAT_YUV420;
 
@@ -567,7 +574,7 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
       thiz->param.mfx.FrameInfo.FrameRateExtD,
       thiz->param.mfx.FrameInfo.FrameRateExtN);
 
-  switch (GST_VIDEO_INFO_FORMAT (info)) {
+  switch (GST_VIDEO_INFO_FORMAT (&info)) {
     case GST_VIDEO_FORMAT_P010_10LE:
       thiz->param.mfx.FrameInfo.FourCC = MFX_FOURCC_P010;
       thiz->param.mfx.FrameInfo.BitDepthLuma = 10;
@@ -647,18 +654,18 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
    */
   if (thiz->param.mfx.CodecId != MFX_CODEC_JPEG &&
       thiz->param.mfx.CodecId != MFX_CODEC_VP9 &&
-      (info->colorimetry.primaries || info->colorimetry.transfer
-          || info->colorimetry.matrix)) {
+      (info.colorimetry.primaries || info.colorimetry.transfer
+          || info.colorimetry.matrix)) {
     memset (&ext_vsi, 0, sizeof (ext_vsi));
     ext_vsi.Header.BufferId = MFX_EXTBUFF_VIDEO_SIGNAL_INFO;
     ext_vsi.Header.BufferSz = sizeof (ext_vsi);
     ext_vsi.ColourDescriptionPresent = 1;
     ext_vsi.ColourPrimaries =
-        gst_video_color_primaries_to_iso (info->colorimetry.primaries);
+        gst_video_color_primaries_to_iso (info.colorimetry.primaries);
     ext_vsi.TransferCharacteristics =
-        gst_video_transfer_function_to_iso (info->colorimetry.transfer);
+        gst_video_transfer_function_to_iso (info.colorimetry.transfer);
     ext_vsi.MatrixCoefficients =
-        gst_video_color_matrix_to_iso (info->colorimetry.matrix);
+        gst_video_color_matrix_to_iso (info.colorimetry.matrix);
     gst_msdkenc_add_extra_param (thiz, (mfxExtBuffer *) & ext_vsi);
   }
 
@@ -1159,14 +1166,15 @@ gst_msdkenc_set_src_caps (GstMsdkEnc * thiz)
 
 #ifndef _WIN32
 static GstBufferPool *
-gst_msdk_create_va_pool (GstMsdkEnc * thiz, GstCaps * caps, guint num_buffers)
+gst_msdk_create_va_pool (GstMsdkEnc * thiz, GstVideoInfo * info,
+    guint num_buffers)
 {
   GstBufferPool *pool = NULL;
   GstAllocator *allocator;
   GArray *formats = NULL;
   GstAllocationParams alloc_params = { 0, 31, 0, 0 };
   GstVaDisplay *display = NULL;
-  GstVideoInfo info = thiz->input_state->info;
+  GstCaps *aligned_caps = NULL;
 
   display = (GstVaDisplay *) gst_msdk_context_get_va_display (thiz->context);
 
@@ -1174,7 +1182,7 @@ gst_msdk_create_va_pool (GstMsdkEnc * thiz, GstCaps * caps, guint num_buffers)
     allocator = gst_va_dmabuf_allocator_new (display);
   } else {
     formats = g_array_new (FALSE, FALSE, sizeof (GstVideoFormat));
-    g_array_append_val (formats, GST_VIDEO_INFO_FORMAT (&info));
+    g_array_append_val (formats, GST_VIDEO_INFO_FORMAT (info));
     allocator = gst_va_allocator_new (display, formats);
   }
 
@@ -1185,12 +1193,20 @@ gst_msdk_create_va_pool (GstMsdkEnc * thiz, GstCaps * caps, guint num_buffers)
     return NULL;
   }
 
+  if (thiz->use_dmabuf && thiz->modifier != DRM_FORMAT_MOD_INVALID) {
+    aligned_caps = gst_msdkcaps_video_info_to_drm_caps (info, thiz->modifier);
+    gst_caps_set_features (aligned_caps, 0,
+        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DMABUF, NULL));
+  } else
+    aligned_caps = gst_video_info_to_caps (info);
+
   pool =
-      gst_va_pool_new_with_config (caps, GST_VIDEO_INFO_SIZE (&info),
+      gst_va_pool_new_with_config (aligned_caps, GST_VIDEO_INFO_SIZE (info),
       num_buffers, 0, VA_SURFACE_ATTRIB_USAGE_HINT_GENERIC, GST_VA_FEATURE_AUTO,
       allocator, &alloc_params);
 
   gst_object_unref (allocator);
+  gst_caps_unref (aligned_caps);
 
   GST_LOG_OBJECT (thiz, "Creating va pool");
   return pool;
@@ -1261,7 +1277,7 @@ gst_msdkenc_create_buffer_pool (GstMsdkEnc * thiz, GstCaps * caps,
   GstVideoInfo info;
   GstVideoAlignment align;
 
-  if (!gst_video_info_from_caps (&info, caps)) {
+  if (!gst_msdkcaps_video_info_from_caps (caps, &info, NULL)) {
     GST_INFO_OBJECT (thiz, "failed to get video info");
     return FALSE;
   }
@@ -1269,7 +1285,7 @@ gst_msdkenc_create_buffer_pool (GstMsdkEnc * thiz, GstCaps * caps,
   gst_msdk_set_video_alignment (&info, 0, 0, &align);
   gst_video_info_align (&info, &align);
 #ifndef _WIN32
-  pool = gst_msdk_create_va_pool (thiz, caps, num_buffers);
+  pool = gst_msdk_create_va_pool (thiz, &info, num_buffers);
 #else
   pool = gst_msdk_create_d3d11_pool (thiz, num_buffers);
 #endif
@@ -1396,13 +1412,16 @@ gst_msdkenc_set_format (GstVideoEncoder * encoder, GstVideoCodecState * state)
    * based pipeline usage. Ideally we should have dmabuf support even with
    * raw-caps negotiation, but we don't have dmabuf-import support in msdk
    * plugin yet */
+#ifndef _WIN32
   /* If VA is set, we do not fallback to DMA. */
   if (!thiz->use_va && sinkpad_can_dmabuf (thiz)) {
     thiz->input_state->caps = gst_caps_make_writable (thiz->input_state->caps);
     gst_caps_set_features (thiz->input_state->caps, 0,
         gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DMABUF, NULL));
     thiz->use_dmabuf = TRUE;
+    thiz->modifier = get_msdkcaps_get_modifier (state->caps);
   }
+#endif
 
   if (!gst_msdkenc_init_encoder (thiz))
     return FALSE;
@@ -1517,7 +1536,7 @@ gst_msdkenc_get_surface_from_frame (GstMsdkEnc * thiz,
   inbuf = frame->input_buffer;
 
   msdk_surface = gst_msdk_import_to_msdk_surface (inbuf, thiz->context,
-      &thiz->input_state->info, GST_MAP_READ);
+      &thiz->aligned_info, GST_MAP_READ);
   if (msdk_surface) {
     msdk_surface->buf = gst_buffer_ref (inbuf);
     return msdk_surface;
@@ -1742,7 +1761,7 @@ gst_msdkenc_propose_allocation (GstVideoEncoder * encoder, GstQuery * query)
     return FALSE;
   }
 
-  if (!gst_video_info_from_caps (&info, caps)) {
+  if (!gst_msdkcaps_video_info_from_caps (caps, &info, NULL)) {
     GST_INFO_OBJECT (encoder, "failed to get video info");
     return FALSE;
   }
@@ -1770,9 +1789,8 @@ gst_msdkenc_propose_allocation (GstVideoEncoder * encoder, GstQuery * query)
     if (gst_buffer_pool_config_get_allocator (config, &allocator, NULL))
       gst_query_add_allocation_param (query, allocator, &params);
     gst_structure_free (config);
+    gst_object_unref (pool);
   }
-
-  gst_object_unref (pool);
 
   return GST_VIDEO_ENCODER_CLASS (parent_class)->propose_allocation (encoder,
       query);
@@ -2001,6 +2019,9 @@ gst_msdkenc_init (GstMsdkEnc * thiz)
   thiz->lowdelay_brc = PROP_LOWDELAY_BRC_DEFAULT;
   thiz->adaptive_i = PROP_ADAPTIVE_I_DEFAULT;
   thiz->adaptive_b = PROP_ADAPTIVE_B_DEFAULT;
+#ifndef _WIN32
+  thiz->modifier = DRM_FORMAT_MOD_INVALID;
+#endif
 
   thiz->ext_coding_props = gst_structure_new (EC_PROPS_STRUCT_NAME,
       EC_PROPS_EXTBRC, G_TYPE_STRING, "off", NULL);

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.h
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.h
@@ -142,6 +142,7 @@ struct _GstMsdkEnc
   gboolean use_va;
   gboolean use_d3d11;
   gboolean initialized;
+  guint64 modifier;
 
   /* element properties */
   gboolean hardware;

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvpp.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvpp.c
@@ -60,6 +60,7 @@
 #include "gstmsdkallocator.h"
 
 #ifndef _WIN32
+#include <libdrm/drm_fourcc.h>
 #include "gstmsdkallocator_libva.h"
 #include <gst/va/gstvaallocator.h>
 #else
@@ -378,8 +379,8 @@ gst_msdkvpp_prepare_output_buffer (GstBaseTransform * trans,
 
 #ifndef _WIN32
 static GstBufferPool *
-gst_msdk_create_va_pool (GstVideoInfo * info, GstMsdkContext * msdk_context,
-    gboolean use_dmabuf, guint min_buffers)
+gst_msdk_create_va_pool (GstMsdkVPP * thiz, GstVideoInfo * info,
+    GstMsdkContext * msdk_context, guint min_buffers, GstPadDirection direction)
 {
   GstBufferPool *pool = NULL;
   GstAllocator *allocator;
@@ -387,8 +388,19 @@ gst_msdk_create_va_pool (GstVideoInfo * info, GstMsdkContext * msdk_context,
   GstAllocationParams alloc_params = { 0, 31, 0, 0 };
   GstVaDisplay *display = NULL;
   GstCaps *aligned_caps = NULL;
+  guint usage_hint = VA_SURFACE_ATTRIB_USAGE_HINT_GENERIC;
+  gboolean use_dmabuf = FALSE;
+  guint64 modifier = DRM_FORMAT_MOD_INVALID;
 
   display = (GstVaDisplay *) gst_msdk_context_get_va_display (msdk_context);
+
+  if (direction == GST_PAD_SINK) {
+    use_dmabuf = thiz->use_sinkpad_dmabuf;
+    modifier = thiz->sink_modifier;
+  } else if (direction == GST_PAD_SRC) {
+    use_dmabuf = thiz->use_srcpad_dmabuf;
+    modifier = thiz->src_modifier;
+  }
 
   if (use_dmabuf)
     allocator = gst_va_dmabuf_allocator_new (display);
@@ -407,12 +419,20 @@ gst_msdk_create_va_pool (GstVideoInfo * info, GstMsdkContext * msdk_context,
       g_array_unref (formats);
     return NULL;
   }
-  aligned_caps = gst_video_info_to_caps (info);
+
+  if (use_dmabuf && modifier != DRM_FORMAT_MOD_INVALID) {
+    aligned_caps = gst_msdkcaps_video_info_to_drm_caps (info, modifier);
+    usage_hint |= VA_SURFACE_ATTRIB_USAGE_HINT_VPP_READ |
+        VA_SURFACE_ATTRIB_USAGE_HINT_VPP_WRITE;
+    gst_caps_set_features (aligned_caps, 0,
+        gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DMABUF, NULL));
+  } else
+    aligned_caps = gst_video_info_to_caps (info);
+
   pool =
       gst_va_pool_new_with_config (aligned_caps,
       GST_VIDEO_INFO_SIZE (info), min_buffers, 0,
-      VA_SURFACE_ATTRIB_USAGE_HINT_GENERIC, GST_VA_FEATURE_AUTO,
-      allocator, &alloc_params);
+      usage_hint, GST_VA_FEATURE_AUTO, allocator, &alloc_params);
 
   gst_object_unref (allocator);
   gst_caps_unref (aligned_caps);
@@ -482,17 +502,14 @@ gst_msdkvpp_create_buffer_pool (GstMsdkVPP * thiz, GstPadDirection direction,
   GstVideoInfo info;
   GstVideoInfo *pool_info = NULL;
   GstVideoAlignment align;
-  gboolean use_dmabuf = FALSE;
 
   if (direction == GST_PAD_SINK) {
     pool_info = &thiz->sinkpad_buffer_pool_info;
-    use_dmabuf = thiz->use_sinkpad_dmabuf;
   } else if (direction == GST_PAD_SRC) {
     pool_info = &thiz->srcpad_buffer_pool_info;
-    use_dmabuf = thiz->use_srcpad_dmabuf;
   }
 
-  if (!gst_video_info_from_caps (&info, caps)) {
+  if (!gst_msdkcaps_video_info_from_caps (caps, &info, NULL)) {
     goto error_no_video_info;
   }
 
@@ -500,8 +517,8 @@ gst_msdkvpp_create_buffer_pool (GstMsdkVPP * thiz, GstPadDirection direction,
   gst_video_info_align (&info, &align);
 
 #ifndef _WIN32
-  pool = gst_msdk_create_va_pool (&info, thiz->context, use_dmabuf,
-      min_num_buffers);
+  pool = gst_msdk_create_va_pool (thiz, &info, thiz->context, min_num_buffers,
+      direction);
 #else
   pool = gst_msdk_create_d3d11_pool (thiz, &info, min_num_buffers, propose);
 #endif
@@ -536,7 +553,6 @@ error_no_pool:
 error_no_video_info:
   {
     GST_INFO_OBJECT (thiz, "Failed to get Video info from caps");
-    gst_object_unref (pool);
     return NULL;
   }
 error_pool_config:
@@ -607,7 +623,6 @@ static gboolean
 gst_msdkvpp_decide_allocation (GstBaseTransform * trans, GstQuery * query)
 {
   GstMsdkVPP *thiz = GST_MSDKVPP (trans);
-  GstVideoInfo info;
   GstCaps *caps;
 
   gst_query_parse_allocation (query, &caps, NULL);
@@ -615,10 +630,7 @@ gst_msdkvpp_decide_allocation (GstBaseTransform * trans, GstQuery * query)
     GST_ERROR_OBJECT (thiz, "Failed to parse the decide_allocation caps");
     return FALSE;
   }
-  if (!gst_video_info_from_caps (&info, caps)) {
-    GST_ERROR_OBJECT (thiz, "Failed to get video info");
-    return FALSE;
-  }
+
   /* We allocate the memory of type that downstream allocation requests */
 #ifndef _WIN32
   if (gst_msdkcaps_has_feature (caps, GST_CAPS_FEATURE_MEMORY_DMABUF)) {
@@ -660,13 +672,16 @@ gst_msdkvpp_propose_allocation (GstBaseTransform * trans,
   guint size;
   guint min_buffers = thiz->async_depth + 1;
 
+  if (gst_base_transform_is_passthrough (trans))
+    return TRUE;
+
   gst_query_parse_allocation (query, &caps, &need_pool);
   if (!caps) {
     GST_ERROR_OBJECT (thiz, "Failed to parse the allocation caps");
     return FALSE;
   }
 
-  if (!gst_video_info_from_caps (&info, caps)) {
+  if (!gst_msdkcaps_video_info_from_caps (caps, &info, NULL)) {
     GST_ERROR_OBJECT (thiz, "Failed to get video info");
     return FALSE;
   }
@@ -1391,9 +1406,15 @@ gst_msdkvpp_set_caps (GstBaseTransform * trans, GstCaps * caps,
           gst_caps_get_features (out_caps, 0)))
     thiz->need_vpp = 1;
 
-  if (!gst_video_info_from_caps (&in_info, caps))
+  thiz->use_sinkpad_dmabuf = gst_msdkcaps_has_feature (caps,
+      GST_CAPS_FEATURE_MEMORY_DMABUF) ? TRUE : FALSE;
+  thiz->use_srcpad_dmabuf = gst_msdkcaps_has_feature (out_caps,
+      GST_CAPS_FEATURE_MEMORY_DMABUF) ? TRUE : FALSE;
+
+  if (!gst_msdkcaps_video_info_from_caps (caps, &in_info, &thiz->sink_modifier))
     goto error_no_video_info;
-  if (!gst_video_info_from_caps (&out_info, out_caps))
+  if (!gst_msdkcaps_video_info_from_caps (out_caps,
+          &out_info, &thiz->src_modifier))
     goto error_no_video_info;
 
   if (!gst_video_info_is_equal (&in_info, &thiz->sinkpad_info))
@@ -1484,11 +1505,8 @@ pad_accept_memory (GstMsdkVPP * thiz, const gchar * mem_type,
   gst_caps_set_features (caps, 0, gst_caps_features_from_string (mem_type));
 
   out_caps = gst_pad_peer_query_caps (pad, caps);
-  if (!out_caps)
-    goto done;
 
-  if (gst_caps_is_any (out_caps) || gst_caps_is_empty (out_caps)
-      || out_caps == caps)
+  if (!out_caps || gst_caps_is_empty (out_caps))
     goto done;
 
   if (gst_msdkcaps_has_feature (out_caps, mem_type))
@@ -1507,11 +1525,9 @@ gst_msdkvpp_fixate_caps (GstBaseTransform * trans,
 {
   GstMsdkVPP *thiz = GST_MSDKVPP (trans);
   GstCaps *result = NULL;
-  gboolean *use_dmabuf;
 
   if (direction == GST_PAD_SRC) {
     result = gst_caps_fixate (othercaps);
-    use_dmabuf = &thiz->use_sinkpad_dmabuf;
   } else {
     /*
      * Override mirroring & rotation properties once video-direction
@@ -1522,7 +1538,6 @@ gst_msdkvpp_fixate_caps (GstBaseTransform * trans,
           (thiz->video_direction, &thiz->mirroring, &thiz->rotation);
 
     result = gst_msdkvpp_fixate_srccaps (thiz, caps, othercaps);
-    use_dmabuf = &thiz->use_srcpad_dmabuf;
   }
 
   GST_DEBUG_OBJECT (trans, "fixated to %" GST_PTR_FORMAT, result);
@@ -1540,7 +1555,6 @@ gst_msdkvpp_fixate_caps (GstBaseTransform * trans,
           direction == GST_PAD_SRC ? GST_PAD_SINK : GST_PAD_SRC, result)) {
     gst_caps_set_features (result, 0,
         gst_caps_features_new (GST_CAPS_FEATURE_MEMORY_DMABUF, NULL));
-    *use_dmabuf = TRUE;
   }
 #else
   if (pad_accept_memory (thiz, GST_CAPS_FEATURE_MEMORY_D3D11_MEMORY,
@@ -1559,19 +1573,23 @@ static GstCaps *
 gst_msdkvpp_transform_caps (GstBaseTransform * trans,
     GstPadDirection direction, GstCaps * caps, GstCaps * filter)
 {
-  GstCaps *out_caps;
+  GstCaps *out_caps = NULL;
+  GstCaps *tmp_caps;
 
   GST_DEBUG_OBJECT (trans,
       "Transforming caps %" GST_PTR_FORMAT " in direction %s", caps,
       (direction == GST_PAD_SINK) ? "sink" : "src");
 
   if (direction == GST_PAD_SINK) {
-    out_caps =
+    tmp_caps =
         gst_pad_get_pad_template_caps (GST_BASE_TRANSFORM_SRC_PAD (trans));
   } else {
-    out_caps =
+    tmp_caps =
         gst_pad_get_pad_template_caps (GST_BASE_TRANSFORM_SINK_PAD (trans));
   }
+
+  if (!out_caps)
+    out_caps = tmp_caps;
 
   if (out_caps && filter) {
     GstCaps *intersection;
@@ -2058,7 +2076,10 @@ gst_msdkvpp_init (GTypeInstance * instance, gpointer g_class)
   thiz->crop_top = PROP_CROP_TOP_DEFAULT;
   thiz->crop_bottom = PROP_CROP_BOTTOM_DEFAULT;
   thiz->hdr_tone_mapping = PROP_HDR_TONE_MAPPING_DEFAULT;
-
+#ifndef _WIN32
+  thiz->sink_modifier = DRM_FORMAT_MOD_INVALID;
+  thiz->src_modifier = DRM_FORMAT_MOD_INVALID;
+#endif
   gst_video_info_init (&thiz->sinkpad_info);
   gst_video_info_init (&thiz->srcpad_info);
 }

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvpp.h
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvpp.h
@@ -92,6 +92,8 @@ struct _GstMsdkVPP
   /* To check if sinkcaps have HDR SEIs*/
   gboolean have_mdcv;
   gboolean have_cll;
+  guint64 sink_modifier;
+  guint64 src_modifier;
 
   /* element properties */
   gboolean hardware;

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvpputil.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvpputil.c
@@ -29,6 +29,11 @@
 #include "msdk-enums.h"
 #include "gstmsdkcaps.h"
 
+#ifndef _WIN32
+#include <libdrm/drm_fourcc.h>
+#include <gst/va/gstvavideoformat.h>
+#endif
+
 #define SWAP_GINT(a, b) do {      \
         const gint t = a; a = b; b = t; \
     } while (0)
@@ -50,6 +55,127 @@ gst_msdkvpp_is_deinterlace_enabled (GstMsdkVPP * msdkvpp, GstVideoInfo * vip)
       break;
   }
   return deinterlace;
+}
+
+/* This help function is to fixate output format for vpp src caps,
+ * when downstream element does not set a specific format, i.e. queried
+ * caps contains a list of formats, vpp src caps will loop the format
+ * list and find one format that matches the vpp sink caps format (in vinfo);
+ * if downstream has set a specific format, we use this format for vpp src caps.
+ */
+static GstCaps *
+fixate_output_format (GstMsdkVPP * thiz, GstVideoInfo * vinfo, GstCaps * caps)
+{
+  GstVideoFormat fmt = GST_VIDEO_FORMAT_UNKNOWN;
+  guint i, size, fixated_idx = 0;
+  GstStructure *s, *out = NULL;
+  GstCapsFeatures *features;
+  GstCaps *ret;
+  const GValue *format;
+  gboolean is_dma = FALSE;
+  gboolean fixate = FALSE;
+#ifndef _WIN32
+  guint64 modifier = DRM_FORMAT_MOD_INVALID;
+  guint32 fourcc;
+#endif
+
+  if (!caps)
+    return NULL;
+  size = gst_caps_get_size (caps);
+
+  for (i = 0; i < size; i++) {
+    s = gst_caps_get_structure (caps, i);
+    features = gst_caps_get_features (caps, i);
+
+    if (gst_caps_features_contains (features, GST_CAPS_FEATURE_MEMORY_DMABUF)) {
+      format = gst_structure_get_value (s, "drm-format");
+      is_dma = TRUE;
+    } else {
+      format = gst_structure_get_value (s, "format");
+      is_dma = FALSE;
+    }
+
+    if (format == NULL)
+      continue;
+
+    if (GST_VALUE_HOLDS_LIST (format)) {
+      gint j, len;
+
+      len = gst_value_list_get_size (format);
+      GST_DEBUG_OBJECT (thiz, "have %d formats", len);
+      for (j = 0; j < len; j++) {
+        const GValue *val;
+
+        val = gst_value_list_get_value (format, j);
+        if (G_VALUE_HOLDS_STRING (val)) {
+#ifndef _WIN32
+          if (is_dma) {
+            fourcc = gst_video_dma_drm_fourcc_from_string
+                (g_value_get_string (val), &modifier);
+            fmt = gst_va_video_format_from_drm_fourcc (fourcc);
+          } else {
+            fmt = gst_video_format_from_string (g_value_get_string (val));
+          }
+#else
+          fmt = gst_video_format_from_string (g_value_get_string (val));
+#endif
+          if (fmt == GST_VIDEO_FORMAT_UNKNOWN)
+            continue;
+          if (fmt == GST_VIDEO_INFO_FORMAT (vinfo)) {
+            fixate = TRUE;
+            fixated_idx = i;
+            break;
+          }
+        }
+      }
+    } else if (G_VALUE_HOLDS_STRING (format)) {
+#ifndef _WIN32
+      if (is_dma) {
+        fourcc = gst_video_dma_drm_fourcc_from_string
+            (g_value_get_string (format), &modifier);
+        fmt = gst_va_video_format_from_drm_fourcc (fourcc);
+      } else {
+        fmt = gst_video_format_from_string (g_value_get_string (format));
+      }
+#else
+      fmt = gst_video_format_from_string (g_value_get_string (format));
+#endif
+      if (fmt == GST_VIDEO_FORMAT_UNKNOWN)
+        continue;
+      fixate = TRUE;
+      break;
+    }
+    if (fixate)
+      break;
+  }
+
+  out = gst_structure_copy (gst_caps_get_structure (caps, fixated_idx));
+  features = gst_caps_features_copy (gst_caps_get_features (caps, fixated_idx));
+
+#ifndef _WIN32
+  if (is_dma) {
+    gchar *drm_fmt_name;
+
+    g_assert (modifier != DRM_FORMAT_MOD_INVALID);
+
+    drm_fmt_name = gst_video_dma_drm_fourcc_to_string
+        (gst_va_drm_fourcc_from_video_format (fmt), modifier);
+
+    gst_structure_set (out, "drm-format", G_TYPE_STRING, drm_fmt_name, NULL);
+    g_free (drm_fmt_name);
+  } else {
+    gst_structure_set (out, "format", G_TYPE_STRING,
+        gst_video_format_to_string (fmt), NULL);
+  }
+#else
+  gst_structure_set (out, "format", G_TYPE_STRING,
+      gst_video_format_to_string (fmt), NULL);
+#endif
+
+  ret = gst_caps_new_full (out, NULL);
+  gst_caps_set_features_simple (ret, features);
+
+  return ret;
 }
 
 static gboolean
@@ -529,26 +655,22 @@ static GstCaps *
 _get_preferred_src_caps (GstMsdkVPP * thiz, GstVideoInfo * vinfo,
     GstCaps * srccaps)
 {
-  GstStructure *structure;
-  GstCaps *outcaps;
+  GstStructure *structure = NULL;
+  GstCaps *outcaps, *fixate_caps;
 
-  structure = gst_caps_get_structure (srccaps, 0);
+  /* Fixate the format */
+  fixate_caps = fixate_output_format (thiz, vinfo, srccaps);
+  if (!fixate_caps)
+    goto fixate_failed;
 
+  structure = gst_caps_get_structure (fixate_caps, 0);
   /* make a copy */
   structure = gst_structure_copy (structure);
+  gst_caps_unref (fixate_caps);
 
   if (thiz->keep_aspect)
     gst_structure_set (structure, "pixel-aspect-ratio", GST_TYPE_FRACTION, 1,
         1, NULL);
-
-  /* Fixate the format */
-  if (gst_video_is_dma_drm_caps (srccaps) &&
-      gst_structure_has_field (structure, "drm-format")) {
-    if (!gst_structure_fixate_field (structure, "drm-format"))
-      goto fixate_failed;
-  } else if (gst_structure_has_field (structure, "format"))
-    if (!gst_structure_fixate_field (structure, "format"))
-      goto fixate_failed;
 
   /* Fixate the frame size */
   if (!fixate_output_frame_size (thiz, vinfo, structure))
@@ -577,7 +699,8 @@ _get_preferred_src_caps (GstMsdkVPP * thiz, GstVideoInfo * vinfo,
 fixate_failed:
   {
     GST_WARNING_OBJECT (thiz, "Could not fixate src caps");
-    gst_structure_free (structure);
+    if (structure)
+      gst_structure_free (structure);
     return NULL;
   }
 interlace_mode_failed:


### PR DESCRIPTION
This is a refacted gst-msdk modifier based on https://github.com/intel-media-ci/gstreamer/pull/69.  Several issues get fixed, including:
1. All supported formats can work with dmacaps (https://github.com/intel-media-ci/gstreamer/pull/69 only works for NV12)
2. [_The changes in gstreamer base class_](https://github.com/intel-media-ci/gstreamer/pull/69/commits/1f8086404cfa3413e34f5da16ccabf512aa05c70)  are too risky to be accepted by upstream, it also blocked the gst-va dma caps pipeline, so remove this part and fix it in gst-msdk encoder.
3. Fix the failure in the windows build.
4. Fix the corrupted display on DG2.