### PR TITLE
va:allocator: We should use the same info when creating pool and mapping

### DIFF
--- a/subprojects/gst-plugins-bad/gst-libs/gst/va/gstvaallocator.c
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/va/gstvaallocator.c
@@ -1169,7 +1169,6 @@ struct _GstVaAllocator
   guint32 fourcc;
   guint32 rt_format;
 
-  GstVideoInfo derived_info;
   GstVideoInfo info;
   guint usage_hint;
 
@@ -1329,9 +1328,7 @@ _update_image_info (GstVaAllocator * va_allocator)
       && va_allocator->surface_format == va_allocator->img_format) {
     if (va_get_derive_image (va_allocator->display, surface, &image)) {
       va_allocator->use_derived = TRUE;
-      va_allocator->derived_info = va_allocator->info;
-      _update_info (&va_allocator->derived_info, &image);
-      va_destroy_image (va_allocator->display, image.image_id);
+      goto done;
     }
     image.image_id = VA_INVALID_ID;     /* reset it */
   }
@@ -1350,6 +1347,7 @@ _update_image_info (GstVaAllocator * va_allocator)
     return FALSE;
   }
 
+done:
   _update_info (&va_allocator->info, &image);
   va_destroy_image (va_allocator->display, image.image_id);
   va_destroy_surfaces (va_allocator->display, &surface, 1);
@@ -1412,24 +1410,21 @@ _va_map_unlocked (GstVaMemory * mem, GstMapFlags flags)
          * problematic */
         use_derived = va_allocator->use_derived && !((flags & GST_MAP_READ)
             || ((flags & GST_MAP_WRITE)
-                && GST_VIDEO_INFO_IS_YUV (&va_allocator->derived_info)));
+                && GST_VIDEO_INFO_IS_YUV (&va_allocator->info)));
         break;
       case GST_VA_IMPLEMENTATION_MESA_GALLIUM:
         /* Reading RGB derived images, with non-standard resolutions,
          * looks like tiled too. TODO(victor): fill a bug in Mesa. */
         use_derived = va_allocator->use_derived && !((flags & GST_MAP_READ)
-            && GST_VIDEO_INFO_IS_RGB (&va_allocator->derived_info));
+            && GST_VIDEO_INFO_IS_RGB (&va_allocator->info));
         break;
       default:
         use_derived = va_allocator->use_derived;
         break;
     }
-#endif
   }
-  if (use_derived)
-    info = &va_allocator->derived_info;
-  else
-    info = &va_allocator->info;
+#endif
+  info = &va_allocator->info;
 
   if (!va_ensure_image (display, mem->surface, info, &mem->image, use_derived))
     return NULL;

--- a/subprojects/gst-plugins-bad/gst-libs/gst/va/gstvaallocator.c
+++ b/subprojects/gst-plugins-bad/gst-libs/gst/va/gstvaallocator.c
@@ -1403,7 +1403,7 @@ _va_map_unlocked (GstVaMemory * mem, GstMapFlags flags)
          * cached, so normal memcpy() access is very slow to read, but
          * it's ok for writing. So let's assume that users won't prefer
          * direct-mapped memory if they request read access. */
-        use_derived = va_allocator->use_derived && !(flags & GST_MAP_READ);
+        use_derived = va_allocator->use_derived;
         break;
       case GST_VA_IMPLEMENTATION_INTEL_I965:
         /* YUV derived images are tiled, so writing them is also


### PR DESCRIPTION
The image pitch/stride from vaDeriveImage and vaCreateImage are different because they use different tile. So we cannot use the image info from vaCreateImage to create the bufferpool and then possibly using derived_info in the mapping. We should constantly use the same info when creating bufferpool and the later mapping.