### PR TITLE
vah265enc: Correct the value of cu_qp_delta flag and depth

### DIFF
--- a/subprojects/gst-plugins-bad/sys/va/gstvah265enc.c
+++ b/subprojects/gst-plugins-bad/sys/va/gstvah265enc.c
@@ -4137,9 +4137,14 @@ _h265_setup_encoding_features (GstVaH265Enc * self)
   self->features.transform_skip_enabled_flag =
       (features.bits.transform_skip != 0);
 
-  self->features.cu_qp_delta_enabled_flag =
-      (self->rc.rc_ctrl_mode != VA_RC_CQP);
-  self->features.diff_cu_qp_delta_depth = features.bits.cu_qp_delta;
+  if (self->rc.rc_ctrl_mode != VA_RC_CQP)
+    self->features.cu_qp_delta_enabled_flag = !!features.bits.cu_qp_delta;
+  else
+    self->features.cu_qp_delta_enabled_flag = FALSE;
+
+  if (self->features.cu_qp_delta_enabled_flag)
+    self->features.diff_cu_qp_delta_depth =
+        self->features.log2_diff_max_min_luma_coding_block_size;
 
   /* TODO: use weighted pred */
   self->features.weighted_pred_flag = FALSE;


### PR DESCRIPTION
According to libva API description, cu_qp_delta in VAConfigAttribValEncHEVCFeatures is supposed to be used as a flag not the value of depth. And if flag enabled, diff_cu_qp_delta_depth should be decided by log2_diff_max_min_luma_coding_block_size.