### PR TITLE
msdkenc: Make ROI encode not a dynamic change feature

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.c
@@ -779,6 +779,7 @@ gst_msdkenc_close_encoder (GstMsdkEnc * thiz)
   g_free (thiz->tasks);
   thiz->tasks = NULL;
 
+  memset (&thiz->enc_cntrl, 0, sizeof (thiz->enc_cntrl));
   memset (&thiz->param, 0, sizeof (thiz->param));
   thiz->num_extra_params = 0;
   thiz->initialized = FALSE;
@@ -1539,7 +1540,7 @@ gst_msdkenc_handle_frame (GstVideoEncoder * encoder, GstVideoCodecFrame * frame)
   FrameData *fdata;
   GstMsdkSurface *surface;
 
-  if (thiz->reconfig || klass->need_reconfig (thiz, frame)) {
+  if (thiz->reconfig) {
     gst_msdkenc_flush_frames (thiz, FALSE);
     gst_msdkenc_close_encoder (thiz);
 
@@ -1548,6 +1549,9 @@ gst_msdkenc_handle_frame (GstVideoEncoder * encoder, GstVideoCodecFrame * frame)
     // This will reinitialized the encoder but keep same input format.
     gst_msdkenc_set_format (encoder, NULL);
   }
+
+  if (klass->need_reconfig (thiz, frame))
+    klass->set_extra_params (thiz, frame);
 
   if (G_UNLIKELY (thiz->context == NULL))
     goto not_inited;

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.h
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.h
@@ -125,6 +125,7 @@ struct _GstMsdkEnc
 
   mfxExtBuffer *extra_params[MAX_EXTRA_PARAMS];
   guint num_extra_params;
+  mfxExtBuffer *roi_extra_param;
 
   /* Additional encoder coding options */
   mfxExtCodingOption2 option2;

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkh264enc.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkh264enc.c
@@ -833,8 +833,14 @@ gst_msdkh264enc_set_extra_params (GstMsdkEnc * encoder,
 {
   GstMsdkH264Enc *h264enc = GST_MSDKH264ENC (encoder);
 
-  if (h264enc->roi[0].NumROI)
-    gst_msdkenc_add_extra_param (encoder, (mfxExtBuffer *) & h264enc->roi[0]);
+  memset(&encoder->enc_cntrl.ExtParam, 0, sizeof (mfxExtBuffer));
+  encoder->enc_cntrl.NumExtParam = 0;
+
+  if (h264enc->roi[0].NumROI) {
+    encoder->roi_extra_param = (mfxExtBuffer *)&h264enc->roi[0];
+    encoder->enc_cntrl.ExtParam = &encoder->roi_extra_param;
+    encoder->enc_cntrl.NumExtParam = 1;
+  }
 }
 
 static gboolean

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkh265enc.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkh265enc.c
@@ -945,8 +945,14 @@ gst_msdkh265enc_set_extra_params (GstMsdkEnc * encoder,
 {
   GstMsdkH265Enc *h265enc = GST_MSDKH265ENC (encoder);
 
-  if (h265enc->roi[0].NumROI)
-    gst_msdkenc_add_extra_param (encoder, (mfxExtBuffer *) & h265enc->roi[0]);
+  memset(&encoder->enc_cntrl.ExtParam, 0, sizeof (mfxExtBuffer));
+  encoder->enc_cntrl.NumExtParam = 0;
+
+  if (h265enc->roi[0].NumROI) {
+     encoder->roi_extra_param = (mfxExtBuffer *)&h265enc->roi[0];
+     encoder->enc_cntrl.ExtParam = &encoder->roi_extra_param;
+     encoder->enc_cntrl.NumExtParam = 1;
+  }
 }
 
 static gboolean


### PR DESCRIPTION
Currently, once new ROI is detected, there will be a dynamic change sequence which resulted in messed up GOP structure. The implementation is to make ROI encode not a dynamic change feature.