### PR TITLE
msdk: Add device env in plugin dependencies

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdk.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdk.c
@@ -90,7 +90,8 @@ static void
 plugin_add_dependencies (GstPlugin * plugin)
 {
 #ifndef _WIN32
-  const gchar *env_vars[] = { "LIBVA_DRIVER_NAME", NULL };
+  const gchar *env_vars[] =
+      { "LIBVA_DRIVER_NAME", "GST_MSDK_DRM_DEVICE", NULL };
   const gchar *kernel_paths[] = { "/dev/dri", NULL };
   const gchar *kernel_names[] = { "card", "render", NULL };
 


### PR DESCRIPTION
Add env vars GST_MSDK_DRM_DEVICE in plugin_add_dependencies to register msdk plugins according to user's choice in a multi-gpu platform.