### PR TITLE
msdk: Modify the caps order when register plugins

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
@@ -887,25 +887,23 @@ static GstCaps *
 _enc_create_sink_caps (GstMsdkContext * context, guint codec_id,
     const ResolutionRange * res, GValue * supported_formats)
 {
-  GstCaps *caps, *dma_caps;
-
-  caps = gst_caps_from_string ("video/x-raw");
-  gst_caps_set_value (caps, "format", supported_formats);
+  GstCaps *caps, *dma_caps, *raw_caps;
 
 #ifndef _WIN32
+  caps = gst_caps_from_string
+      ("video/x-raw(memory:VAMemory), format=(string){ NV12 }");
   dma_caps = _create_dma_drm_caps (context, GST_MSDK_JOB_ENCODER,
       supported_formats);
   gst_caps_append (caps, dma_caps);
-
-  gst_caps_append (caps,
-      gst_caps_from_string
-      ("video/x-raw(memory:VAMemory), format=(string){ NV12 }"));
 #else
   VAR_UNUSED (dma_caps);
-  gst_caps_append (caps,
-      gst_caps_from_string
-      ("video/x-raw(memory:D3D11Memory), format=(string){ NV12 }"));
+  caps = gst_caps_from_string
+      ("video/x-raw(memory:D3D11Memory), format=(string){ NV12 }");
 #endif
+
+  raw_caps = gst_caps_from_string ("video/x-raw");
+  gst_caps_set_value (raw_caps, "format", supported_formats);
+  gst_caps_append (caps, raw_caps);
 
   gst_caps_set_simple (caps,
       "width", GST_TYPE_INT_RANGE, res->min_width, res->max_width,
@@ -1207,29 +1205,27 @@ _dec_create_src_caps (GstMsdkContext * context,
     mfxSession * session, guint codec_id,
     mfxDecoderDescription * dec_desc, GValue * supported_formats)
 {
-  GstCaps *caps, *dma_caps;
+  GstCaps *caps, *dma_caps, *raw_caps;
   ResolutionRange res = { 1, G_MAXUINT16, 1, G_MAXUINT16 };
 
   if (!_dec_get_resolution_range (session, dec_desc, codec_id, &res))
     return NULL;
 
-  caps = gst_caps_from_string ("video/x-raw");
-  gst_caps_set_value (caps, "format", supported_formats);
-
 #ifndef _WIN32
+  caps = gst_caps_from_string
+      ("video/x-raw(memory:VAMemory), format=(string){ NV12 }");
   dma_caps = _create_dma_drm_caps (context, GST_MSDK_JOB_DECODER,
       supported_formats);
   gst_caps_append (caps, dma_caps);
-
-  gst_caps_append (caps,
-      gst_caps_from_string
-      ("video/x-raw(memory:VAMemory), format=(string){ NV12 }"));
 #else
   VAR_UNUSED (dma_caps);
-  gst_caps_append (caps,
-      gst_caps_from_string
-      ("video/x-raw(memory:D3D11Memory), format=(string){ NV12 }"));
+  caps = gst_caps_from_string
+      ("video/x-raw(memory:D3D11Memory), format=(string){ NV12 }");
 #endif
+
+  raw_caps = gst_caps_from_string ("video/x-raw");
+  gst_caps_set_value (raw_caps, "format", supported_formats);
+  gst_caps_append (caps, raw_caps);
 
   gst_caps_set_simple (caps,
       "width", GST_TYPE_INT_RANGE, res.min_width, res.max_width,
@@ -1460,24 +1456,21 @@ static GstCaps *
 _vpp_create_caps (GstMsdkContext * context,
     GValue * supported_fmts, ResolutionRange * res)
 {
-  GstCaps *caps, *dma_caps;
-
-  caps = gst_caps_from_string ("video/x-raw");
-  gst_caps_set_value (caps, "format", supported_fmts);
+  GstCaps *caps, *dma_caps, *raw_caps;
 
 #ifndef _WIN32
+  caps = gst_caps_from_string ("video/x-raw(memory:VAMemory), "
+      "format=(string){ NV12, VUYA, P010_10LE }");
   dma_caps = _create_dma_drm_caps (context, GST_MSDK_JOB_VPP, supported_fmts);
   gst_caps_append (caps, dma_caps);
-
-  gst_caps_append (caps,
-      gst_caps_from_string ("video/x-raw(memory:VAMemory), "
-          "format=(string){ NV12, VUYA, P010_10LE }"));
 #else
   VAR_UNUSED (dma_caps);
-  gst_caps_append (caps,
-      gst_caps_from_string ("video/x-raw(memory:D3D11Memory), "
-          "format=(string){ NV12, VUYA, P010_10LE }"));
+  caps = gst_caps_from_string ("video/x-raw(memory:D3D11Memory), "
+      "format=(string){ NV12, VUYA, P010_10LE }");
 #endif
+  raw_caps = gst_caps_from_string ("video/x-raw");
+  gst_caps_set_value (raw_caps, "format", supported_fmts);
+  gst_caps_append (caps, raw_caps);
 
   gst_caps_set_simple (caps,
       "width", GST_TYPE_INT_RANGE, res->min_width, res->max_width,

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.c
@@ -2038,26 +2038,6 @@ gst_msdkcaps_set_strings (GstCaps * caps,
 }
 
 gboolean
-gst_msdkcaps_remove_structure (GstCaps * caps, const gchar * features)
-{
-  guint size;
-  GstCapsFeatures *f;
-
-  g_return_val_if_fail (GST_IS_CAPS (caps), FALSE);
-  g_return_val_if_fail (features != NULL, FALSE);
-
-  size = gst_caps_get_size (caps);
-  f = gst_caps_features_from_string (features);
-
-  for (guint i = 0; i < size; i++) {
-    if (gst_caps_features_is_equal (f, gst_caps_get_features (caps, i)))
-      gst_caps_remove_structure (caps, i);
-  }
-
-  return TRUE;
-}
-
-gboolean
 gst_msdkcaps_video_info_from_caps (const GstCaps * caps,
     GstVideoInfo * info, guint64 * modifier)
 {

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.h
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkcaps.h
@@ -79,9 +79,6 @@ gst_msdkcaps_set_strings (GstCaps * caps,
     const gchar * features, const char * field, const gchar * strings);
 
 gboolean
-gst_msdkcaps_remove_structure (GstCaps * caps, const gchar * features);
-
-gboolean
 gst_msdkcaps_video_info_from_caps (const GstCaps * caps,
     GstVideoInfo * info, guint64 * modifier);
 

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvc1dec.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvc1dec.c
@@ -243,12 +243,7 @@ gst_msdkvc1dec_register (GstPlugin * plugin,
 
   cdata = g_new (MsdkDecCData, 1);
   cdata->sink_caps = gst_caps_ref (sink_caps);
-#ifndef _WIN32
   cdata->src_caps = gst_caps_ref (src_caps);
-#else
-  cdata->src_caps = gst_caps_copy (src_caps);
-  gst_msdkcaps_remove_structure (cdata->src_caps, "memory:D3D11Memory");
-#endif
 
   GST_MINI_OBJECT_FLAG_SET (cdata->sink_caps,
       GST_MINI_OBJECT_FLAG_MAY_BE_LEAKED);

--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvp8dec.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkvp8dec.c
@@ -244,12 +244,6 @@ gst_msdkvp8dec_register (GstPlugin * plugin,
   cdata = g_new (MsdkDecCData, 1);
   cdata->sink_caps = gst_caps_ref (sink_caps);
   cdata->src_caps = gst_caps_copy (src_caps);
-#ifndef _WIN32
-  cdata->src_caps = gst_caps_ref (src_caps);
-#else
-  cdata->src_caps = gst_caps_copy (src_caps);
-  gst_msdkcaps_remove_structure (cdata->src_caps, "memory:D3D11Memory");
-#endif
 
   GST_MINI_OBJECT_FLAG_SET (cdata->sink_caps,
       GST_MINI_OBJECT_FLAG_MAY_BE_LEAKED);


### PR DESCRIPTION
With this patch, the caps is registered in the order of memory features as: VAMemory, DMABuf then raw caps in linux path, and D3D11Memory then raw caps in windows path. It helps to prioritize the video memory for all msdk elements when doing negotiation.