### PR TITLE
msdkenc: Guard the read of thiz->initialized with the modification of…

### DIFF
--- a/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.c
+++ b/subprojects/gst-plugins-bad/sys/msdk/gstmsdkenc.c
@@ -500,11 +500,6 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
   guint i;
   mfxExtVideoSignalInfo ext_vsi;
 
-  if (thiz->initialized) {
-    GST_DEBUG_OBJECT (thiz, "Already initialized");
-    return TRUE;
-  }
-
   if (!thiz->context) {
     GST_WARNING_OBJECT (thiz, "No MSDK Context");
     return FALSE;
@@ -522,6 +517,12 @@ gst_msdkenc_init_encoder (GstMsdkEnc * thiz)
   }
 
   GST_OBJECT_LOCK (thiz);
+  if (thiz->initialized) {
+    GST_DEBUG_OBJECT (thiz, "Already initialized");
+    GST_OBJECT_UNLOCK (thiz);
+    return TRUE;
+  }
+
   session = gst_msdk_context_get_session (thiz->context);
   thiz->codename = msdk_get_platform_codename (session);
 


### PR DESCRIPTION
… this value

This is to avoid wrongly read/write thiz->initialized when multi-thread invoking encoder init function, it is possible when user apps deploy multi-thread to dynamically change encoder's settings.